### PR TITLE
refactor(api): centralize API requests via axios instance

### DIFF
--- a/src/components/Checkin/CheckIn.tsx
+++ b/src/components/Checkin/CheckIn.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import { Charts } from "./Charts";
 import axios from "axios";
 import {
-    BASE_URL,
     highEnergyPleasantAccent,
     highEnergyPleasantGlow,
     highEnergyPleasantPrimary,
@@ -30,6 +29,7 @@ import {useSelector} from "react-redux";
 import MorphingWaveButton from "@/components/Checkin/MorphingButton.tsx";
 import { useNavigate } from "react-router-dom";
 import mixpanelService from "@/services/MixpanelService.ts";
+import api from "@/services/Api.ts";
 
 
 
@@ -94,7 +94,7 @@ const CheckIn = () => {
     const addCheckin = async () => {
         try {
             setIsLoading(true)
-             await axios.post(`${BASE_URL}/api/checkin/new`, payload, {
+             await api.post(`/checkin/new`, payload, {
                 withCredentials: true,
             });
             // console.log("Check-in submitted:", response.data.data);

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -9,12 +9,12 @@ import {InteractiveHoverButton} from "@/components/magicui/interactive-hover-but
 import {useDispatch} from "react-redux";
 import {toast} from "sonner";
 import  axios from "axios";
-import {BASE_URL} from "@/utils/constants.ts";
 import {addUser} from "@/utils/slice/userSlice.ts";
 import {Mail, Lock, UserRound, HeartHandshake} from "lucide-react"
 import Header from "@/components/Header.tsx";
 import {GoogleLogin, GoogleOAuthProvider} from "@react-oauth/google";
 import mixpanelService from "@/services/MixpanelService.ts";
+import api from "@/services/Api.ts";
 
 const Login=()=>{
 
@@ -32,7 +32,7 @@ const Login=()=>{
     const handleGoogleLogin=async (credentialResponse: any)=>{
         try{
             setIsLoading(true);
-            const response=await axios.post(`${BASE_URL}/api/auth/google-auth`,{credential: credentialResponse.credential},{withCredentials:true})
+            const response=await api.post(`/auth/google-auth`,{credential: credentialResponse.credential},{withCredentials:true})
             dispatch(addUser(response?.data?.user));
             navigate('/main');
             toast.success("Google login successful!");
@@ -54,7 +54,7 @@ const Login=()=>{
     const handleLogin=async ()=>{
         try{
             setIsLoading(true);
-            const response=await axios.post(`${BASE_URL}/api/auth/login`,
+            const response=await api.post(`/auth/login`,
                 {
                     email:emailId,
                     password:password,
@@ -81,7 +81,7 @@ const Login=()=>{
         try {
             mixpanelService.trackButtonClick('Guest Login', { location: 'Login Page' });
             setIsLoading(true);
-            const response = await axios.post(`${BASE_URL}/api/auth/guest-login`, null, {withCredentials: true},)
+            const response = await api.post(`/auth/guest-login`, null, {withCredentials: true},)
             dispatch(addUser(response?.data?.user))
             navigate('/main')
             toast.info('Guest Login , Limited 5 min session')
@@ -102,7 +102,7 @@ const Login=()=>{
     const handleSignUp=async ()=>{
         try{
             setIsLoading(true);
-            const response=await axios.post(`${BASE_URL}/api/auth/signup`,
+            const response=await api.post(`/auth/signup`,
                 {
                     email:emailId,
                     password:password,

--- a/src/components/Profile/AddNoteModal.tsx
+++ b/src/components/Profile/AddNoteModal.tsx
@@ -1,8 +1,7 @@
 import { type Dispatch, type SetStateAction, useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import axios from "axios";
-import { BASE_URL } from "@/utils/constants.ts";
 import type {Note} from "@/utils/types.ts";
+import api from "@/services/Api.ts";
 
 interface AddNoteModalProps {
     setShowNoteModal: Dispatch<SetStateAction<boolean>>;
@@ -38,14 +37,14 @@ const AddNoteModal = ({ setShowNoteModal, initialNoteData,refreshNotes }: AddNot
     const handleSaveNote = async () => {
         try {
             if (initialNoteData && initialNoteData._id) {
-                const response = await axios.patch(
-                    `${BASE_URL}/api/selfNote/update/${initialNoteData._id}`,
+                const response = await api.patch(
+                    `/selfNote/update/${initialNoteData._id}`,
                     payload,
                     { withCredentials: true }
                 );
                 console.log("Note updated:", response.data);
             } else {
-                const response = await axios.post(`${BASE_URL}/api/selfNote/new`, payload, { withCredentials: true });
+                const response = await api.post(`/selfNote/new`, payload, { withCredentials: true });
                 console.log("New note added:", response.data);
             }
 

--- a/src/components/Profile/Profile.tsx
+++ b/src/components/Profile/Profile.tsx
@@ -5,7 +5,6 @@ import { motion } from "motion/react";
 import { IconUpload } from "@tabler/icons-react";
 import { useDropzone } from "react-dropzone";
 import axios from "axios";
-import { BASE_URL } from "@/utils/constants.ts";
 import useFetchUser from "@/utils/hooks/useFetchUser.ts";
 import ProfileEditModal from "@/components/Profile/ProfileEditModal.tsx";
 // import AddNoteModal from "@/components/Profile/AddNoteModal.tsx";
@@ -16,6 +15,7 @@ import Footer from "@/components/Footer.tsx";
 import ThemeChanger from "./ThemeChanger";
 import ApiBox from "@/components/Profile/ApiBox.tsx";
 import mixpanelService from "@/services/MixpanelService.ts";
+import api from "@/services/Api.ts";
 
 const CLOUD_NAME = import.meta.env.VITE_CLOUD_NAME!;
 const UPLOAD_PRESET = import.meta.env.VITE_UPLOAD_PRESET!;
@@ -104,7 +104,7 @@ const Profile = () => {
     const uploadImageToDb = async () => {
         try {
             if (uploadedImage) {
-                const response = await axios.patch(`${BASE_URL}/api/profile/edit`, {
+                const response = await api.patch(`/profile/edit`, {
                     photoUrl: uploadedImage,
                 }, { withCredentials: true });
                 console.log(response.data);

--- a/src/components/Profile/ProfileEditModal.tsx
+++ b/src/components/Profile/ProfileEditModal.tsx
@@ -1,11 +1,11 @@
 import { type Dispatch, type SetStateAction, useState } from "react";
 import { motion } from "framer-motion";
 import axios from "axios";
-import { BASE_URL } from "@/utils/constants.ts";
 import useFetchUser from "@/utils/hooks/useFetchUser.ts";
 import type {User} from "@/utils/types.ts";
 import {toast} from "sonner";
 import {Button} from "@/components/ui/button.tsx";
+import api from "@/services/Api.ts";
 
 
 interface ProfileEditModalProps {
@@ -25,7 +25,7 @@ const ProfileEditModal = ({user, setShowModal }: ProfileEditModalProps) => {
 
     const editProfileInfo = async () => {
         try {
-             await axios.patch(`${BASE_URL}/api/profile/edit`, {
+             await api.patch(`/profile/edit`, {
                 firstName: payload.firstName,
                 lastName: payload.lastName,
                 bio: payload.bio,

--- a/src/components/Tools/ToolsPage.tsx
+++ b/src/components/Tools/ToolsPage.tsx
@@ -8,7 +8,6 @@ import type {CheckIn, User} from "@/utils/types.ts";
 import { useSelector } from "react-redux";
 import type { TechniqueCard, Category } from "@/utils/types";
 import {
-  BASE_URL,
   highEnergyPleasantAccent,
   highEnergyPleasantGlow,
   highEnergyPleasantPrimary,
@@ -32,6 +31,7 @@ import FeedbackCard from "@/components/Tools/FeedbackCard.tsx";
 import axios from "axios";
 import {toast} from "sonner";
 import mixpanelService from "@/services/MixpanelService.ts";
+import api from "@/services/Api.ts";
 
 const colorMapping: Record<Category, {
   primary: string;
@@ -105,7 +105,7 @@ export function ToolsPage() {
   const handleFeedback=async ()=>{
     try{
       setFeedbackLoading(true)
-      const response=await axios.post(`${BASE_URL}/api/feedback/new/`,{
+      const response=await api.post(`/feedback/new/`,{
         toolName:toolName,
         rating:sliderValue[0],
         checkIn:latest?._id

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+const api = axios.create({
+    baseURL: '/api',
+    withCredentials: true,
+});
+
+export default api;

--- a/src/utils/hooks/useFetchCheckIn.ts
+++ b/src/utils/hooks/useFetchCheckIn.ts
@@ -1,15 +1,15 @@
 import axios from "axios";
-import {BASE_URL} from "@/utils/constants.ts";
 import {toast} from "sonner";
 import { useDispatch } from "react-redux";
 import {addCheckIns} from "@/utils/slice/checkInSlice.ts";
+import api from "@/services/Api.ts";
 const useFetchCheckIn=()=>{
 
     const dispatch = useDispatch();
 
     const getAllCheckin=async ()=>{
         try{
-            const response=await axios.get(`${BASE_URL}/api/checkin/getAll`,{withCredentials:true})
+            const response=await api.get(`/checkin/getAll`,{withCredentials:true})
             dispatch(addCheckIns(response?.data?.data))
         }
         catch(err){

--- a/src/utils/hooks/useFetchUser.ts
+++ b/src/utils/hooks/useFetchUser.ts
@@ -1,11 +1,10 @@
-import axios from 'axios';
-import {BASE_URL} from "@/utils/constants.ts";
 import {addUser} from "@/utils/slice/userSlice.ts";
 import {useDispatch} from "react-redux";
+import api from "@/services/Api.ts";
 const useFetchUser=()=>{
     const dispatch = useDispatch();
     const fetchUser=async ()=>{
-        const response=await axios.get(`${BASE_URL}/api/profile/get`,{withCredentials:true})
+        const response=await api.get(`/profile/get`,{withCredentials:true})
         dispatch(addUser(response.data.data))
     }
     return fetchUser;

--- a/src/utils/hooks/useGetAllEmotions.ts
+++ b/src/utils/hooks/useGetAllEmotions.ts
@@ -1,10 +1,10 @@
 import axios from "axios";
-import {BASE_URL} from "@/utils/constants.ts";
 import {toast} from "sonner";
 import {useDispatch, useSelector} from "react-redux";
 import type {Emotion} from "@/utils/types.ts";
 import {addEmotions} from "@/utils/slice/emotionSlice.ts";
 import {useEffect} from "react";
+import api from "@/services/Api.ts";
 
 const useGetAllEmotions = () => {
 
@@ -13,7 +13,7 @@ const useGetAllEmotions = () => {
 
     const getAllEmotions = async () => {
         try {
-            const response = await axios.get(`${BASE_URL}/api/emotion/getAll`, {
+            const response = await api.get(`/emotion/getAll`, {
                 withCredentials: true,
             })
             dispatch(addEmotions(response?.data?.data))

--- a/src/utils/hooks/useGetAllFeedback.ts
+++ b/src/utils/hooks/useGetAllFeedback.ts
@@ -1,8 +1,8 @@
 import axios from "axios";
-import {BASE_URL} from "@/utils/constants.ts";
 import {toast} from "sonner";
 import {useDispatch} from "react-redux";
 import {addFeedback} from "@/utils/slice/feedbackSlice.ts";
+import api from "@/services/Api.ts";
 
 const useGetAllFeedback = () => {
 
@@ -10,7 +10,7 @@ const useGetAllFeedback = () => {
 
     const getAllFeedback = async () => {
         try {
-            const response = await axios.get(`${BASE_URL}/api/feedback/getAll`, {
+            const response = await api.get(`/feedback/getAll`, {
                 withCredentials: true,
             })
             dispatch(addFeedback(response?.data?.data))

--- a/src/utils/hooks/useGetAllTags.ts
+++ b/src/utils/hooks/useGetAllTags.ts
@@ -1,8 +1,8 @@
 import axios from "axios";
-import {BASE_URL} from "@/utils/constants.ts";
 import {useDispatch} from "react-redux";
 import {addActivityTag, addPeopleTag, addPlaceTag} from "@/utils/slice/tagsSlice.ts";
 import {toast} from "sonner";
+import api from "@/services/Api.ts";
 
 const useGetAllTags=()=>{
 
@@ -11,9 +11,9 @@ const useGetAllTags=()=>{
     const getAllTagsSeparately = async () => {
 
         try {
-            const activityResponse = await axios.get(`${BASE_URL}/api/activityTag/getAll`,{withCredentials:true},);
-            const peopleResponse = await axios.get(`${BASE_URL}/api/peopleTag/getAll`,{withCredentials:true},);
-            const placeResponse = await axios.get(`${BASE_URL}/api/placeTag/getAll`,{withCredentials:true},);
+            const activityResponse = await api.get(`/activityTag/getAll`,{withCredentials:true},);
+            const peopleResponse = await api.get(`/peopleTag/getAll`,{withCredentials:true},);
+            const placeResponse = await api.get(`/placeTag/getAll`,{withCredentials:true},);
 
             dispatch(addActivityTag(activityResponse.data.data))
             dispatch(addPlaceTag(placeResponse.data.data))

--- a/src/utils/hooks/useGuestDelete.ts
+++ b/src/utils/hooks/useGuestDelete.ts
@@ -1,12 +1,12 @@
 import axios from "axios";
 import {toast} from "sonner";
-import {BASE_URL} from "@/utils/constants.ts";
+import api from "@/services/Api.ts";
 const useGuestDelete = () => {
 
 
     const deleteGuest = async () => {
         try{
-            await axios.delete(`${BASE_URL}/api/auth/delete-guest`,{withCredentials:true})
+            await api.delete(`/auth/delete-guest`,{withCredentials:true})
 
         }
         catch (err){

--- a/src/utils/hooks/useLogout.ts
+++ b/src/utils/hooks/useLogout.ts
@@ -1,15 +1,15 @@
 import  axios from 'axios'
 import {toast} from "sonner";
-import {BASE_URL} from "@/utils/constants.ts";
 import { useDispatch } from 'react-redux';
 import {removeUser} from "@/utils/slice/userSlice.ts";
+import api from "@/services/Api.ts";
 const useLogOut=()=>{
     
     const dispatch =useDispatch()
     
     const  handleLogOut=async ()=>{
         try{
-            await axios.post(`${BASE_URL}/api/auth/logout`,null,{withCredentials:true})
+            await api.post(`/auth/logout`,null,{withCredentials:true})
             dispatch(removeUser())
             toast.success("User logged out successfully");
         }

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,12 @@
 {
   "rewrites": [
-    { "source": "/(.*)", "destination": "/index.html" }
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    },
+    {
+      "source": "/api/:path*",
+      "destination": "https://ruok-backend.onrender.com/api/:path*"
+    }
   ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,4 +11,13 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  server: {
+    proxy: {
+      '/api': {
+        target: 'https://ruok-backend.onrender.com',
+        changeOrigin: true,
+        secure: false,
+      }
+    }
+  }
 })


### PR DESCRIPTION
- Removed redundant `axios` import and `BASE_URL` usage across components and hooks.
- Introduced shared `api` instance in `src/services/Api.ts` for API requests with consistent configurations.
- Updated Vercel and Vite configurations to support API proxying to backend.